### PR TITLE
[FEAT] API 에서 받은 데이터를 CollectionView 에 로딩 및 오타 수정

### DIFF
--- a/Gaongil/Controllers/DetailViewController.swift
+++ b/Gaongil/Controllers/DetailViewController.swift
@@ -16,6 +16,7 @@ class DetailViewController: UIViewController {
     
     var shared = ResponseManager.shared
     let coreDataManager = CoreDataManager.shared
+    var result = [Row]()
     var selectedIndex = 0
     
 //    var favoriteLawIsSelected : Bool = false{
@@ -113,7 +114,6 @@ class DetailViewController: UIViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName:"star"), style: .plain, target: self, action: #selector(favoriteLaw))
         self.navigationController?.navigationBar.tintColor = .customSelectedGreen
-        print(selectedIndex)
         
         [lawTitleLabel, cardView, contentTextView].forEach { view.addSubview($0) }
         cardView.addSubview(informationStackView)
@@ -124,20 +124,19 @@ class DetailViewController: UIViewController {
                            radius: 6,
                            opacity: 0.2)
         
-//        shared.fetchLawData() { [weak self] _ in
-//            self?.lawTitleLabel.text = self?.shared.rows[0][self!.selectedIndex].billName ?? String()
-//            self?.instituteView.contentLabel.text = self?.shared.rows[0][self!.selectedIndex].currCommittee ?? String()
-//            self?.progressView.contentLabel.text = self?.shared.rows[0][self!.selectedIndex].procResultCd ?? String()
-//            self?.proposerView.contentLabel.text = self?.shared.rows[0][self!.selectedIndex].proposer ?? String()
-//            self?.suggestionDateView.contentLabel.text = self?.shared.rows[0][self!.selectedIndex].proposeDt ?? String()
-//            self?.contentTextView.text = self?.shared.rows[0][self!.selectedIndex].linkUrl ?? String()
-//        }
+            lawTitleLabel.text = shared.rows[0][selectedIndex].billName ?? String()
+            instituteView.contentLabel.text = shared.rows[0][selectedIndex].currCommittee ?? String()
+            progressView.contentLabel.text = shared.rows[0][selectedIndex].procResultCd ?? String()
+            proposerView.contentLabel.text = shared.rows[0][selectedIndex].proposer ?? String()
+            suggestionDateView.contentLabel.text = shared.rows[0][selectedIndex].proposeDt ?? String()
+            contentTextView.text = self.shared.rows[0][selectedIndex].linkUrl ?? String()
+        
     }
     
     private func configureConstraints() {
         NSLayoutConstraint.activate([
             lawTitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: screenWidth / 22.94),
-            lawTitleLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: screenHeight / 20.09 + 30),
+            lawTitleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: screenHeight / 30.145),
             
             cardView.topAnchor.constraint(equalTo: lawTitleLabel.bottomAnchor, constant: screenHeight / 25.09),
             cardView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: screenWidth / 22.94),

--- a/Gaongil/Controllers/SelectCategoryViewController.swift
+++ b/Gaongil/Controllers/SelectCategoryViewController.swift
@@ -67,7 +67,7 @@ class SelectCategoryViewController: UIViewController {
     @objc func startButtonTapped() {
         for data in categories {
             if data.isCategorySelected == true {
-                coreDataManager.saveCoreData(name: data.name, isCategorySelected: data.isCategorySelected) { _ in }
+                coreDataManager.saveCommitteeCoreData(name: data.name, isCategorySelected: data.isCategorySelected) { _ in }
             }
         }
         

--- a/Gaongil/Manager/CoreDataManager.swift
+++ b/Gaongil/Manager/CoreDataManager.swift
@@ -28,6 +28,18 @@ class CoreDataManager {
         return fetchedResultsController
     }()
     
+    lazy var fetchedFavoriteController: NSFetchedResultsController<Favorite> = {
+        let fetchRequest: NSFetchRequest<Favorite> = Favorite.fetchRequest()
+
+        let sort = NSSortDescriptor(key: "name", ascending: true)
+//        fetchRequest.sortDescriptors = [sort]
+        fetchRequest.fetchBatchSize = 50
+
+        let fetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest,
+                                                                  managedObjectContext: container!, sectionNameKeyPath: nil, cacheName: nil)
+        return fetchedResultsController
+    }()
+    
     // MARK: - Save Core Data
     
     func saveCommitteeCoreData(name: String, isCategorySelected: Bool, completion: @escaping (Bool) -> Void) {

--- a/Gaongil/Manager/ResponseManager.swift
+++ b/Gaongil/Manager/ResponseManager.swift
@@ -19,8 +19,7 @@ class ResponseManager {
     private init() { }
     
     func fetchLawData(name: String, _ completionHandler: @escaping (([[Row]]) -> Void)) {
-        print(name)
-        let committeeName = CommitteeName(rawValue: name)?.fullName ?? String()
+        let committeeName = name
         let url = URLComponents(string: APIConstants.committeeURL + committeeName)!
         
         let header: HTTPHeaders = [
@@ -41,7 +40,6 @@ class ResponseManager {
                             
                             /// 전체 JSON 데이터
                             guard let lists = firstRow.list else { return }
-                            print("나는 lists: \(lists)")
                             
                             /// row 데이터들만 모아놓은 프로퍼티
                             let rowBoxes = lists.compactMap { $0.row }

--- a/Gaongil/Model/CommitteeName.swift
+++ b/Gaongil/Model/CommitteeName.swift
@@ -26,7 +26,7 @@ enum CommitteeName: String {
 
     var fullName: String {
         switch self {
-        case .고용: return "산업통상자원중소벤쳐기업위원회"
+        case .고용: return "산업통상자원중소벤처기업위원회"
         case .보건: return "보건복지위원회"
         case .기술: return "과학기술정보방송통신위원회"
         case .환경: return "환경노동위원회"

--- a/Gaongil/Views/CommitteeListView.swift
+++ b/Gaongil/Views/CommitteeListView.swift
@@ -14,6 +14,8 @@ class CommitteeListView: UIView, NSFetchedResultsControllerDelegate {
     
     let coreDataManager = CoreDataManager.shared
     var categoryList : [String] = ["전체"]
+    weak var delegate: CommitteeListViewDelegate?
+    var selectedCommitteeName = ""
 
     
     lazy var fetchedResultsController: NSFetchedResultsController<Committee> = {
@@ -76,6 +78,10 @@ class CommitteeListView: UIView, NSFetchedResultsControllerDelegate {
             categorycollectionView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor)
         ])
     }
+    
+    @objc private func onClickTestButton(){
+        self.delegate?.onClickButton(committeeName: selectedCommitteeName)
+    }
 }
 
 // MARK: - UICollectionView Setting
@@ -110,4 +116,20 @@ extension CommitteeListView: UICollectionViewDataSource {
 
         return cell
     }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CommitteeCellId", for: indexPath) as! CommitteeCustomCell
+        
+        print(categoryList[indexPath.row])
+        
+        selectedCommitteeName = CommitteeName(rawValue: categoryList[indexPath.row])?.fullName ?? String()
+        print(selectedCommitteeName)
+        onClickTestButton()
+    
+    }
+}
+
+protocol CommitteeListViewDelegate: class {
+    func onClickButton(committeeName: String)
 }


### PR DESCRIPTION
## 작업내용
- [x] CommitteeListView 를 눌렀을 때 해당 위원회 명을 출력
- [x] 해당 위원회 이름으로 해당 하는 데이터를 API 를 통해 불러옴
- [x] 받은 데이터를 `todayLawCollectionView` 에 `reloadData()` 로 CollectionView 출력
- [x] "고용" 에 대한 enum 값 수정 

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 후|
|:---:|
|<img width="40%" src="https://user-images.githubusercontent.com/45564605/201261629-f79a52f2-2b61-49c4-b46d-25dc6f65b01d.mp4">|

## 리뷰포인트
- 상단의 위원회 셀을 눌렀을 떄 하단의 CollectionView 에 맞는 데이터가 출력되는지 확인 바랍니다.

## Checklist
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인


